### PR TITLE
hometask 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <properties>
         <java.version>21</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
+        <java-jwt.version>4.4.0</java-jwt.version>
     </properties>
 
     <dependencies>
@@ -29,11 +31,33 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>${java-jwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/mipt/todolist/api/AuthController.java
+++ b/src/main/java/com/mipt/todolist/api/AuthController.java
@@ -1,0 +1,34 @@
+package com.mipt.todolist.api;
+
+import com.mipt.todolist.dto.LoginRequest;
+import com.mipt.todolist.dto.LoginResponse;
+import com.mipt.todolist.security.JwtUtils;
+import jakarta.validation.Valid;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtils jwtUtils;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtUtils jwtUtils) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtils = jwtUtils;
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
+        );
+        return new LoginResponse(jwtUtils.generateToken(authentication), "Bearer");
+    }
+}

--- a/src/main/java/com/mipt/todolist/api/ProfileController.java
+++ b/src/main/java/com/mipt/todolist/api/ProfileController.java
@@ -1,0 +1,26 @@
+package com.mipt.todolist.api;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ProfileController {
+
+    @GetMapping("/profile")
+    public Map<String, Object> profile(Authentication authentication) {
+        return Map.of(
+                "username", authentication.getName(),
+                "roles", authentication.getAuthorities()
+        );
+    }
+
+    @GetMapping("/docs")
+    public Map<String, String> docs() {
+        return Map.of("message", "Readable documentation");
+    }
+}

--- a/src/main/java/com/mipt/todolist/api/TasksGatewayController.java
+++ b/src/main/java/com/mipt/todolist/api/TasksGatewayController.java
@@ -1,0 +1,62 @@
+package com.mipt.todolist.api;
+
+import com.mipt.todolist.client.ExternalTasksClient;
+import com.mipt.todolist.dto.TaskCreateDto;
+import com.mipt.todolist.dto.TaskResponseDto;
+import com.mipt.todolist.service.TasksGatewayService;
+import com.mipt.todolist.validation.OnCreate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/tasks")
+public class TasksGatewayController {
+
+    private final TasksGatewayService tasksGatewayService;
+
+    public TasksGatewayController(TasksGatewayService tasksGatewayService) {
+        this.tasksGatewayService = tasksGatewayService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TaskResponseDto> createTask(@Validated(OnCreate.class) @RequestBody TaskCreateDto request) {
+        ExternalTasksClient.CreatedTask createdTask = tasksGatewayService.createTask(request);
+        if (createdTask.location() == null) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(createdTask.task());
+        }
+        return ResponseEntity.created(createdTask.location()).body(createdTask.task());
+    }
+
+    @GetMapping("/{id}")
+    public TaskResponseDto getTask(@PathVariable("id") String id) {
+        return tasksGatewayService.getTask(id);
+    }
+
+    @GetMapping
+    public List<TaskResponseDto> getTasks(@RequestParam(value = "completed", required = false) Boolean completed,
+                                          @RequestParam(value = "limit", required = false) Integer limit) {
+        return tasksGatewayService.getTasks(completed, limit);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable("id") String id) {
+        tasksGatewayService.deleteTask(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/unstable")
+    public String unstable(@RequestParam("mode") String mode) {
+        return tasksGatewayService.callUnstable(mode);
+    }
+}

--- a/src/main/java/com/mipt/todolist/client/ExternalTasksClient.java
+++ b/src/main/java/com/mipt/todolist/client/ExternalTasksClient.java
@@ -1,0 +1,153 @@
+package com.mipt.todolist.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mipt.todolist.dto.TaskCreateDto;
+import com.mipt.todolist.dto.TaskResponseDto;
+import com.mipt.todolist.exception.ExternalApiException;
+import com.mipt.todolist.exception.TaskNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Component
+public class ExternalTasksClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalTasksClient.class);
+    private static final int MAX_LOGGED_BODY_LENGTH = 500;
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public ExternalTasksClient(RestClient externalTasksRestClient, ObjectMapper objectMapper) {
+        this.restClient = externalTasksRestClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public CreatedTask createTask(TaskCreateDto request) {
+        ResponseEntity<TaskResponseDto> response = restClient.post()
+                .uri("/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .onStatus(status -> status.value() == HttpStatus.NOT_FOUND.value(), (clientRequest, clientResponse) -> {
+                    throw taskNotFound(readBody(clientResponse));
+                })
+                .onStatus(status -> status.is5xxServerError(), (clientRequest, clientResponse) -> {
+                    throw externalApiException(clientResponse.getStatusCode().value(), readBody(clientResponse),
+                            clientResponse.getHeaders().getContentType());
+                })
+                .toEntity(TaskResponseDto.class);
+
+        return new CreatedTask(response.getBody(), response.getHeaders().getLocation());
+    }
+
+    public TaskResponseDto getTask(String id) {
+        return restClient.get()
+                .uri("/tasks/{id}", id)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> status.value() == HttpStatus.NOT_FOUND.value(), (clientRequest, clientResponse) -> {
+                    throw taskNotFound(readBody(clientResponse));
+                })
+                .onStatus(status -> status.is5xxServerError(), (clientRequest, clientResponse) -> {
+                    throw externalApiException(clientResponse.getStatusCode().value(), readBody(clientResponse),
+                            clientResponse.getHeaders().getContentType());
+                })
+                .body(TaskResponseDto.class);
+    }
+
+    public List<TaskResponseDto> getTasks(Boolean completed, Integer limit) {
+        return restClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path("/tasks");
+                    if (completed != null) {
+                        uriBuilder.queryParam("completed", completed);
+                    }
+                    if (limit != null) {
+                        uriBuilder.queryParam("limit", limit);
+                    }
+                    return uriBuilder.build();
+                })
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> status.is5xxServerError(), (clientRequest, clientResponse) -> {
+                    throw externalApiException(clientResponse.getStatusCode().value(), readBody(clientResponse),
+                            clientResponse.getHeaders().getContentType());
+                })
+                .body(new ParameterizedTypeReference<>() {
+                });
+    }
+
+    public void deleteTask(String id) {
+        restClient.delete()
+                .uri("/tasks/{id}", id)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> status.value() == HttpStatus.NOT_FOUND.value(), (clientRequest, clientResponse) -> {
+                    throw taskNotFound(readBody(clientResponse));
+                })
+                .onStatus(status -> status.is5xxServerError(), (clientRequest, clientResponse) -> {
+                    throw externalApiException(clientResponse.getStatusCode().value(), readBody(clientResponse),
+                            clientResponse.getHeaders().getContentType());
+                })
+                .toBodilessEntity();
+    }
+
+    private TaskNotFoundException taskNotFound(byte[] body) {
+        ProblemDetail problemDetail = parseProblemDetail(body);
+        String detail = problemDetail != null && problemDetail.getDetail() != null
+                ? problemDetail.getDetail()
+                : "Task not found in external API";
+        return TaskNotFoundException.withMessage(detail);
+    }
+
+    private ExternalApiException externalApiException(int statusCode, byte[] body, MediaType contentType) {
+        if (contentType == null || !MediaType.APPLICATION_JSON.isCompatibleWith(contentType)) {
+            log.warn("Unexpected external API content type: {}, body={}", contentType, limitedBody(body));
+        }
+        return new ExternalApiException("External API returned status " + statusCode, statusCode);
+    }
+
+    private ProblemDetail parseProblemDetail(byte[] body) {
+        if (body == null || body.length == 0) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(body, ProblemDetail.class);
+        } catch (IOException ex) {
+            log.warn("Could not parse external API ProblemDetail body={}", limitedBody(body));
+            return null;
+        }
+    }
+
+    private byte[] readBody(org.springframework.http.client.ClientHttpResponse response) throws IOException {
+        return response.getBody().readAllBytes();
+    }
+
+    private String limitedBody(byte[] body) {
+        if (body == null || body.length == 0) {
+            return "";
+        }
+        String value = new String(body, StandardCharsets.UTF_8).replaceAll("\\s+", " ").trim();
+        if (value.length() <= MAX_LOGGED_BODY_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_LOGGED_BODY_LENGTH) + "...";
+    }
+
+    public record CreatedTask(TaskResponseDto task, URI location) {
+    }
+}

--- a/src/main/java/com/mipt/todolist/client/ExternalTasksClient.java
+++ b/src/main/java/com/mipt/todolist/client/ExternalTasksClient.java
@@ -106,6 +106,21 @@ public class ExternalTasksClient {
                 .toBodilessEntity();
     }
 
+    public String callUnstable(String mode) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/unstable")
+                        .queryParam("mode", mode)
+                        .build())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .onStatus(status -> status.is5xxServerError(), (clientRequest, clientResponse) -> {
+                    throw externalApiException(clientResponse.getStatusCode().value(), readBody(clientResponse),
+                            clientResponse.getHeaders().getContentType());
+                })
+                .body(String.class);
+    }
+
     private TaskNotFoundException taskNotFound(byte[] body) {
         ProblemDetail problemDetail = parseProblemDetail(body);
         String detail = problemDetail != null && problemDetail.getDetail() != null

--- a/src/main/java/com/mipt/todolist/config/ExternalApiProperties.java
+++ b/src/main/java/com/mipt/todolist/config/ExternalApiProperties.java
@@ -1,0 +1,46 @@
+package com.mipt.todolist.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "app.external-api")
+public class ExternalApiProperties {
+
+    private String baseUrl = "http://localhost:8080/external/v1";
+    private Duration connectTimeout = Duration.ofSeconds(1);
+    private Duration readTimeout = Duration.ofSeconds(2);
+    private String userAgent = "todolist-gateway/1.0";
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+}

--- a/src/main/java/com/mipt/todolist/config/RestClientConfig.java
+++ b/src/main/java/com/mipt/todolist/config/RestClientConfig.java
@@ -1,0 +1,38 @@
+package com.mipt.todolist.config;
+
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(ExternalApiProperties.class)
+public class RestClientConfig {
+
+    @Bean
+    public RestClient externalTasksRestClient(RestClient.Builder builder, ExternalApiProperties properties) {
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(Timeout.of(properties.getConnectTimeout()))
+                .setResponseTimeout(Timeout.of(properties.getReadTimeout()))
+                .build();
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        requestFactory.setConnectTimeout(properties.getConnectTimeout());
+
+        return builder
+                .baseUrl(properties.getBaseUrl())
+                .requestFactory(requestFactory)
+                .defaultHeader(HttpHeaders.USER_AGENT, properties.getUserAgent())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/mipt/todolist/config/SecurityConfig.java
+++ b/src/main/java/com/mipt/todolist/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package com.mipt.todolist.config;
+
+import com.mipt.todolist.security.JwtAuthFilter;
+import com.mipt.todolist.security.PepperPasswordEncoder;
+import com.mipt.todolist.security.RestAccessDeniedHandler;
+import com.mipt.todolist.security.RestAuthenticationEntryPoint;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+    private final RestAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter,
+                          RestAuthenticationEntryPoint authenticationEntryPoint,
+                          RestAccessDeniedHandler accessDeniedHandler) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/profile").hasRole("USER")
+                        .requestMatchers("/api/v1/docs").hasAuthority("READ_PRIVILEGE")
+                        .requestMatchers("/api/v1/tasks/**").authenticated()
+                        .requestMatchers("/actuator/health", "/actuator/metrics").permitAll()
+                        .requestMatchers("/external/**").permitAll()
+                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+                        .anyRequest().permitAll())
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(@Value("${app.security.password.pepper}") String pepper) {
+        return new PepperPasswordEncoder(pepper);
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername("user")
+                        .password(passwordEncoder.encode("password"))
+                        .authorities("ROLE_USER")
+                        .build(),
+                User.withUsername("reader")
+                        .password(passwordEncoder.encode("password"))
+                        .authorities("ROLE_USER", "READ_PRIVILEGE")
+                        .build()
+        );
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/mipt/todolist/config/WebConfig.java
+++ b/src/main/java/com/mipt/todolist/config/WebConfig.java
@@ -29,8 +29,10 @@ public class WebConfig implements WebMvcConfigurer {
         config.addAllowedMethod("OPTIONS");
         config.addAllowedHeader("Authorization");
         config.addAllowedHeader("Content-Type");
+        config.addAllowedHeader("X-Trace-Id");
         config.addExposedHeader("X-Total-Count");
         config.addExposedHeader(ApiVersionResponseFilter.HEADER_API_VERSION);
+        config.addExposedHeader("X-Trace-Id");
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);

--- a/src/main/java/com/mipt/todolist/dto/LoginRequest.java
+++ b/src/main/java/com/mipt/todolist/dto/LoginRequest.java
@@ -1,0 +1,27 @@
+package com.mipt.todolist.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/mipt/todolist/dto/LoginResponse.java
+++ b/src/main/java/com/mipt/todolist/dto/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.mipt.todolist.dto;
+
+public class LoginResponse {
+    private String accessToken;
+    private String tokenType;
+
+    public LoginResponse(String accessToken, String tokenType) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+}

--- a/src/main/java/com/mipt/todolist/exception/ExternalApiException.java
+++ b/src/main/java/com/mipt/todolist/exception/ExternalApiException.java
@@ -1,0 +1,20 @@
+package com.mipt.todolist.exception;
+
+public class ExternalApiException extends RuntimeException {
+
+    private final int statusCode;
+
+    public ExternalApiException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public ExternalApiException(String message, int statusCode, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/com/mipt/todolist/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mipt/todolist/exception/GlobalExceptionHandler.java
@@ -124,6 +124,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
     }
 
+    @ExceptionHandler(ExternalApiException.class)
+    public ResponseEntity<ErrorResponse> handleExternalApi(ExternalApiException ex, HttpServletRequest request) {
+        ErrorResponse body = baseError(HttpStatus.BAD_GATEWAY, ex.getMessage(), request, ex);
+        body.setDetails(Map.of("externalStatus", ex.getStatusCode()));
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(body);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneric(Exception ex, HttpServletRequest request) {
         ErrorResponse body = baseError(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request, ex);

--- a/src/main/java/com/mipt/todolist/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mipt/todolist/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.mipt.todolist.exception;
 
 import com.mipt.todolist.dto.ErrorResponse;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -129,6 +130,12 @@ public class GlobalExceptionHandler {
         ErrorResponse body = baseError(HttpStatus.BAD_GATEWAY, ex.getMessage(), request, ex);
         body.setDetails(Map.of("externalStatus", ex.getStatusCode()));
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(body);
+    }
+
+    @ExceptionHandler(RequestNotPermitted.class)
+    public ResponseEntity<ErrorResponse> handleRateLimit(RequestNotPermitted ex, HttpServletRequest request) {
+        ErrorResponse body = baseError(HttpStatus.TOO_MANY_REQUESTS, "Rate limit exceeded", request, null);
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(body);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/mipt/todolist/exception/TaskNotFoundException.java
+++ b/src/main/java/com/mipt/todolist/exception/TaskNotFoundException.java
@@ -8,4 +8,12 @@ public class TaskNotFoundException extends RuntimeException {
     public TaskNotFoundException(String id) {
         super("Task not found: " + id);
     }
+
+    public static TaskNotFoundException withMessage(String message) {
+        return new TaskNotFoundException(message, true);
+    }
+
+    private TaskNotFoundException(String message, boolean rawMessage) {
+        super(message);
+    }
 }

--- a/src/main/java/com/mipt/todolist/external/ExternalApiController.java
+++ b/src/main/java/com/mipt/todolist/external/ExternalApiController.java
@@ -1,0 +1,157 @@
+package com.mipt.todolist.external;
+
+import com.mipt.todolist.dto.TaskCreateDto;
+import com.mipt.todolist.dto.TaskResponseDto;
+import com.mipt.todolist.dto.TaskUpdateDto;
+import com.mipt.todolist.model.Priority;
+import com.mipt.todolist.validation.OnCreate;
+import com.mipt.todolist.validation.OnUpdate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RestController
+@RequestMapping("/external/v1")
+public class ExternalApiController {
+
+    private final Map<String, TaskResponseDto> tasks = new ConcurrentHashMap<>();
+
+    public ExternalApiController() {
+        TaskResponseDto task = new TaskResponseDto();
+        task.setId("demo-task");
+        task.setTitle("External demo task");
+        task.setDescription("Seed task from external emulator");
+        task.setCompleted(false);
+        task.setCreatedAt(LocalDateTime.now());
+        task.setPriority(Priority.MEDIUM);
+        tasks.put(task.getId(), task);
+    }
+
+    @PostMapping(value = "/tasks", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<TaskResponseDto> createTask(@Validated(OnCreate.class) @RequestBody TaskCreateDto request) {
+        TaskResponseDto task = new TaskResponseDto();
+        task.setId(UUID.randomUUID().toString());
+        task.setTitle(request.getTitle());
+        task.setDescription(request.getDescription());
+        task.setCompleted(false);
+        task.setCreatedAt(LocalDateTime.now());
+        task.setDueDate(request.getDueDate());
+        task.setPriority(request.getPriority());
+        task.setTags(request.getTags());
+        tasks.put(task.getId(), task);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(task.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(task);
+    }
+
+    @GetMapping(value = "/tasks/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getTask(@PathVariable("id") String id) {
+        TaskResponseDto task = tasks.get(id);
+        if (task == null) {
+            return notFound(id);
+        }
+        return ResponseEntity.ok(task);
+    }
+
+    @GetMapping(value = "/tasks", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<TaskResponseDto> getTasks(@RequestParam(value = "completed", required = false) Boolean completed,
+                                          @RequestParam(value = "limit", required = false) Integer limit) {
+        return tasks.values().stream()
+                .filter(task -> completed == null || task.isCompleted() == completed)
+                .sorted(Comparator.comparing(TaskResponseDto::getCreatedAt))
+                .limit(limit == null || limit < 0 ? Long.MAX_VALUE : limit)
+                .toList();
+    }
+
+    @PutMapping(value = "/tasks/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> updateTask(@PathVariable("id") String id,
+                                        @Validated(OnUpdate.class) @RequestBody TaskUpdateDto request) {
+        TaskResponseDto task = tasks.get(id);
+        if (task == null) {
+            return notFound(id);
+        }
+        if (request.getTitle() != null) {
+            task.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            task.setDescription(request.getDescription());
+        }
+        if (request.getCompleted() != null) {
+            task.setCompleted(request.getCompleted());
+        }
+        if (request.getDueDate() != null) {
+            task.setDueDate(request.getDueDate());
+        }
+        if (request.getPriority() != null) {
+            task.setPriority(request.getPriority());
+        }
+        if (request.getTags() != null) {
+            task.setTags(request.getTags());
+        }
+        return ResponseEntity.ok(task);
+    }
+
+    @DeleteMapping("/tasks/{id}")
+    public ResponseEntity<?> deleteTask(@PathVariable("id") String id) {
+        TaskResponseDto removed = tasks.remove(id);
+        if (removed == null) {
+            return notFound(id);
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/unstable")
+    public ResponseEntity<String> unstable(@RequestParam("mode") String mode) throws InterruptedException {
+        return switch (mode) {
+            case "timeout" -> {
+                Thread.sleep(3_500);
+                yield ResponseEntity.ok("ok");
+            }
+            case "500" -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body("{\"message\":\"external service error\"}");
+            case "429" -> ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .header(HttpHeaders.RETRY_AFTER, "5")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body("{\"message\":\"rate limit exceeded\"}");
+            case "html" -> ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .contentType(MediaType.TEXT_HTML)
+                    .body("<html><body><h1>Bad Gateway</h1></body></html>");
+            default -> ResponseEntity.badRequest()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body("{\"message\":\"unsupported unstable mode\"}");
+        };
+    }
+
+    private ResponseEntity<?> notFound(String id) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, "Task not found: " + id);
+        problemDetail.setTitle("Task not found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(problemDetail);
+    }
+}

--- a/src/main/java/com/mipt/todolist/logging/AccessLogFilter.java
+++ b/src/main/java/com/mipt/todolist/logging/AccessLogFilter.java
@@ -1,0 +1,40 @@
+package com.mipt.todolist.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+public class AccessLogFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessLogFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        long start = System.nanoTime();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long timeMs = (System.nanoTime() - start) / 1_000_000;
+            String traceId = MDC.get(TraceIdFilter.MDC_TRACE_ID);
+            log.info("HTTP {} {} -> status={} timeMs={} trace={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    timeMs,
+                    traceId);
+        }
+    }
+}

--- a/src/main/java/com/mipt/todolist/logging/TokenMasker.java
+++ b/src/main/java/com/mipt/todolist/logging/TokenMasker.java
@@ -1,0 +1,19 @@
+package com.mipt.todolist.logging;
+
+public final class TokenMasker {
+
+    private static final int VISIBLE_CHARS = 6;
+
+    private TokenMasker() {
+    }
+
+    public static String mask(String token) {
+        if (token == null || token.isBlank()) {
+            return "";
+        }
+        if (token.length() <= VISIBLE_CHARS * 2) {
+            return "***";
+        }
+        return token.substring(0, VISIBLE_CHARS) + "***" + token.substring(token.length() - VISIBLE_CHARS);
+    }
+}

--- a/src/main/java/com/mipt/todolist/logging/TraceIdFilter.java
+++ b/src/main/java/com/mipt/todolist/logging/TraceIdFilter.java
@@ -1,0 +1,43 @@
+package com.mipt.todolist.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_TRACE_ID = "X-Trace-Id";
+    public static final String MDC_TRACE_ID = "traceId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String traceId = resolveTraceId(request);
+        MDC.put(MDC_TRACE_ID, traceId);
+        response.setHeader(HEADER_TRACE_ID, traceId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_TRACE_ID);
+        }
+    }
+
+    private String resolveTraceId(HttpServletRequest request) {
+        String traceId = request.getHeader(HEADER_TRACE_ID);
+        if (traceId == null || traceId.isBlank()) {
+            return UUID.randomUUID().toString();
+        }
+        return traceId.trim();
+    }
+}

--- a/src/main/java/com/mipt/todolist/security/JwtAuthFilter.java
+++ b/src/main/java/com/mipt/todolist/security/JwtAuthFilter.java
@@ -1,0 +1,47 @@
+package com.mipt.todolist.security;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtUtils jwtUtils;
+
+    public JwtAuthFilter(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String header = request.getHeader(AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            try {
+                JwtUtils.DecodedToken decodedToken = jwtUtils.verify(token);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        decodedToken.username(),
+                        null,
+                        decodedToken.authorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (JWTVerificationException ex) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/mipt/todolist/security/JwtAuthFilter.java
+++ b/src/main/java/com/mipt/todolist/security/JwtAuthFilter.java
@@ -1,10 +1,13 @@
 package com.mipt.todolist.security;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.mipt.todolist.logging.TokenMasker;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -15,6 +18,7 @@ import java.io.IOException;
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthFilter.class);
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
 
@@ -40,6 +44,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (JWTVerificationException ex) {
                 SecurityContextHolder.clearContext();
+                log.warn("Invalid JWT token: {}", TokenMasker.mask(token));
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/mipt/todolist/security/JwtUtils.java
+++ b/src/main/java/com/mipt/todolist/security/JwtUtils.java
@@ -1,0 +1,68 @@
+package com.mipt.todolist.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
+@Component
+public class JwtUtils {
+
+    private final String issuer;
+    private final Duration expiration;
+    private final Algorithm algorithm;
+    private final JWTVerifier verifier;
+
+    public JwtUtils(@Value("${app.security.jwt.issuer}") String issuer,
+                    @Value("${app.security.jwt.secret}") String secret,
+                    @Value("${app.security.jwt.expiration}") Duration expiration) {
+        this.issuer = issuer;
+        this.expiration = expiration;
+        this.algorithm = Algorithm.HMAC256(secret);
+        this.verifier = JWT.require(algorithm)
+                .withIssuer(issuer)
+                .build();
+    }
+
+    public String generateToken(Authentication authentication) {
+        Instant now = Instant.now();
+        List<String> authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+        return JWT.create()
+                .withIssuer(issuer)
+                .withSubject(authentication.getName())
+                .withIssuedAt(now)
+                .withExpiresAt(now.plus(expiration))
+                .withClaim("authorities", authorities)
+                .sign(algorithm);
+    }
+
+    public DecodedToken verify(String token) {
+        DecodedJWT jwt = verifier.verify(token);
+        List<String> authorities = jwt.getClaim("authorities").asList(String.class);
+        return new DecodedToken(jwt.getSubject(), toAuthorities(authorities));
+    }
+
+    private Collection<SimpleGrantedAuthority> toAuthorities(List<String> authorities) {
+        if (authorities == null) {
+            return List.of();
+        }
+        return authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    public record DecodedToken(String username, Collection<SimpleGrantedAuthority> authorities) {
+    }
+}

--- a/src/main/java/com/mipt/todolist/security/PepperPasswordEncoder.java
+++ b/src/main/java/com/mipt/todolist/security/PepperPasswordEncoder.java
@@ -1,0 +1,28 @@
+package com.mipt.todolist.security;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PepperPasswordEncoder implements PasswordEncoder {
+
+    private final String pepper;
+    private final BCryptPasswordEncoder delegate = new BCryptPasswordEncoder();
+
+    public PepperPasswordEncoder(String pepper) {
+        this.pepper = pepper;
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return delegate.encode(withPepper(rawPassword));
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return delegate.matches(withPepper(rawPassword), encodedPassword);
+    }
+
+    private String withPepper(CharSequence rawPassword) {
+        return rawPassword + pepper;
+    }
+}

--- a/src/main/java/com/mipt/todolist/security/RestAccessDeniedHandler.java
+++ b/src/main/java/com/mipt/todolist/security/RestAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.mipt.todolist.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mipt.todolist.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        ErrorResponse body = new ErrorResponse();
+        body.setTimestamp(Instant.now());
+        body.setStatus(HttpStatus.FORBIDDEN.value());
+        body.setError(HttpStatus.FORBIDDEN.getReasonPhrase());
+        body.setMessage("Access denied");
+        body.setPath(request.getRequestURI());
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/mipt/todolist/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/mipt/todolist/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.mipt.todolist.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mipt.todolist.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorResponse body = new ErrorResponse();
+        body.setTimestamp(Instant.now());
+        body.setStatus(HttpStatus.UNAUTHORIZED.value());
+        body.setError(HttpStatus.UNAUTHORIZED.getReasonPhrase());
+        body.setMessage("Authentication required");
+        body.setPath(request.getRequestURI());
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/mipt/todolist/service/TasksGatewayService.java
+++ b/src/main/java/com/mipt/todolist/service/TasksGatewayService.java
@@ -1,0 +1,98 @@
+package com.mipt.todolist.service;
+
+import com.mipt.todolist.client.ExternalTasksClient;
+import com.mipt.todolist.dto.TaskCreateDto;
+import com.mipt.todolist.dto.TaskResponseDto;
+import com.mipt.todolist.exception.TaskNotFoundException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class TasksGatewayService {
+
+    private final ExternalTasksClient externalTasksClient;
+
+    public TasksGatewayService(ExternalTasksClient externalTasksClient) {
+        this.externalTasksClient = externalTasksClient;
+    }
+
+    @RateLimiter(name = "externalApi")
+    @CircuitBreaker(name = "externalApi", fallbackMethod = "createTaskFallback")
+    public ExternalTasksClient.CreatedTask createTask(TaskCreateDto request) {
+        return externalTasksClient.createTask(request);
+    }
+
+    @RateLimiter(name = "externalApi")
+    @CircuitBreaker(name = "externalApi", fallbackMethod = "getTaskFallback")
+    public TaskResponseDto getTask(String id) {
+        return externalTasksClient.getTask(id);
+    }
+
+    @RateLimiter(name = "externalApi")
+    @CircuitBreaker(name = "externalApi", fallbackMethod = "getTasksFallback")
+    public List<TaskResponseDto> getTasks(Boolean completed, Integer limit) {
+        return externalTasksClient.getTasks(completed, limit);
+    }
+
+    @RateLimiter(name = "externalApi")
+    @CircuitBreaker(name = "externalApi", fallbackMethod = "deleteTaskFallback")
+    public void deleteTask(String id) {
+        externalTasksClient.deleteTask(id);
+    }
+
+    @RateLimiter(name = "externalApi")
+    @CircuitBreaker(name = "externalApi", fallbackMethod = "unstableFallback")
+    public String callUnstable(String mode) {
+        return externalTasksClient.callUnstable(mode);
+    }
+
+    public ExternalTasksClient.CreatedTask createTaskFallback(TaskCreateDto request, Throwable throwable) {
+        rethrowNotFound(throwable);
+        TaskResponseDto task = fallbackTask("fallback-create", request.getTitle(), "Task was not created in external API");
+        task.setDueDate(request.getDueDate());
+        task.setPriority(request.getPriority());
+        task.setTags(request.getTags());
+        return new ExternalTasksClient.CreatedTask(task, null);
+    }
+
+    public TaskResponseDto getTaskFallback(String id, Throwable throwable) {
+        rethrowNotFound(throwable);
+        return fallbackTask(id, "External task unavailable", "Fallback response because external API is unavailable");
+    }
+
+    public List<TaskResponseDto> getTasksFallback(Boolean completed, Integer limit, Throwable throwable) {
+        rethrowNotFound(throwable);
+        TaskResponseDto task = fallbackTask("fallback-list", "External tasks unavailable",
+                "Fallback list because external API is unavailable");
+        task.setCompleted(completed != null && completed);
+        return List.of(task);
+    }
+
+    public void deleteTaskFallback(String id, Throwable throwable) {
+        rethrowNotFound(throwable);
+    }
+
+    public String unstableFallback(String mode, Throwable throwable) {
+        return "fallback for unstable mode: " + mode;
+    }
+
+    private TaskResponseDto fallbackTask(String id, String title, String description) {
+        TaskResponseDto task = new TaskResponseDto();
+        task.setId(id);
+        task.setTitle(title);
+        task.setDescription(description);
+        task.setCompleted(false);
+        task.setCreatedAt(LocalDateTime.now());
+        return task;
+    }
+
+    private void rethrowNotFound(Throwable throwable) {
+        if (throwable instanceof TaskNotFoundException taskNotFoundException) {
+            throw taskNotFoundException;
+        }
+    }
+}

--- a/src/main/java/com/mipt/todolist/service/TasksGatewayService.java
+++ b/src/main/java/com/mipt/todolist/service/TasksGatewayService.java
@@ -6,6 +6,7 @@ import com.mipt.todolist.dto.TaskResponseDto;
 import com.mipt.todolist.exception.TaskNotFoundException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -51,7 +52,7 @@ public class TasksGatewayService {
     }
 
     public ExternalTasksClient.CreatedTask createTaskFallback(TaskCreateDto request, Throwable throwable) {
-        rethrowNotFound(throwable);
+        rethrowExpected(throwable);
         TaskResponseDto task = fallbackTask("fallback-create", request.getTitle(), "Task was not created in external API");
         task.setDueDate(request.getDueDate());
         task.setPriority(request.getPriority());
@@ -60,12 +61,12 @@ public class TasksGatewayService {
     }
 
     public TaskResponseDto getTaskFallback(String id, Throwable throwable) {
-        rethrowNotFound(throwable);
+        rethrowExpected(throwable);
         return fallbackTask(id, "External task unavailable", "Fallback response because external API is unavailable");
     }
 
     public List<TaskResponseDto> getTasksFallback(Boolean completed, Integer limit, Throwable throwable) {
-        rethrowNotFound(throwable);
+        rethrowExpected(throwable);
         TaskResponseDto task = fallbackTask("fallback-list", "External tasks unavailable",
                 "Fallback list because external API is unavailable");
         task.setCompleted(completed != null && completed);
@@ -73,10 +74,11 @@ public class TasksGatewayService {
     }
 
     public void deleteTaskFallback(String id, Throwable throwable) {
-        rethrowNotFound(throwable);
+        rethrowExpected(throwable);
     }
 
     public String unstableFallback(String mode, Throwable throwable) {
+        rethrowExpected(throwable);
         return "fallback for unstable mode: " + mode;
     }
 
@@ -90,9 +92,12 @@ public class TasksGatewayService {
         return task;
     }
 
-    private void rethrowNotFound(Throwable throwable) {
+    private void rethrowExpected(Throwable throwable) {
         if (throwable instanceof TaskNotFoundException taskNotFoundException) {
             throw taskNotFoundException;
+        }
+        if (throwable instanceof RequestNotPermitted requestNotPermitted) {
+            throw requestNotPermitted;
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,9 +20,48 @@ app:
     directory: uploads
   cors:
     allowed-origin: "http://localhost:3000"
+  security:
+    jwt:
+      issuer: "todolist"
+      secret: "change-me-to-a-long-secret-for-hometask-4"
+      expiration: 30m
+    password:
+      pepper: "change-me-pepper"
+  external-api:
+    base-url: "http://localhost:${server.port}/external/v1"
+    connect-timeout: 1s
+    read-timeout: 2s
+    user-agent: "todolist-gateway/1.0"
 
 springdoc:
   api-docs:
     path: /v3/api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics
+  endpoint:
+    health:
+      show-details: when_authorized
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      externalApi:
+        sliding-window-type: count_based
+        sliding-window-size: 6
+        minimum-number-of-calls: 4
+        failure-rate-threshold: 50
+        permitted-number-of-calls-in-half-open-state: 2
+        wait-duration-in-open-state: 10s
+        register-health-indicator: true
+  ratelimiter:
+    instances:
+      externalApi:
+        limit-for-period: 5
+        limit-refresh-period: 10s
+        timeout-duration: 0

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,6 +59,8 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 2
         wait-duration-in-open-state: 10s
         register-health-indicator: true
+        ignore-exceptions:
+          - com.mipt.todolist.exception.TaskNotFoundException
   ratelimiter:
     instances:
       externalApi:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -10,3 +10,8 @@ app:
       expiration: 30m
     password:
       pepper: "test-pepper"
+  external-api:
+    base-url: "http://localhost:8080/external/v1"
+    connect-timeout: 1s
+    read-timeout: 2s
+    user-agent: "todolist-gateway-test/1.0"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,3 +1,12 @@
 spring:
   profiles:
     active: test
+
+app:
+  security:
+    jwt:
+      issuer: "todolist-test"
+      secret: "test-secret-for-hometask-4"
+      expiration: 30m
+    password:
+      pepper: "test-pepper"


### PR DESCRIPTION
## Что сделано

### Внутреннее API и Security
- Реализован `POST /api/v1/auth/login` с выдачей JWT
- Реализованы защищенные endpoints:
  - `GET /api/v1/profile` - только `ROLE_USER`
  - `GET /api/v1/docs` - только `READ_PRIVILEGE`
- Настроен `SecurityFilterChain`, stateless-сессии и отключенный CSRF
- Добавлен JWT `OncePerRequestFilter` с проверкой подписи и `exp`
- Настроены пользователи `user/password` и `reader/password`
- Пароли хранятся через BCrypt + pepper из конфигурации
- Добавлены JSON-ответы для `401` и `403`

### Gateway к внешнему API
- Реализованы endpoints:
  - `POST /api/v1/tasks`
  - `GET /api/v1/tasks/{id}`
  - `GET /api/v1/tasks?completed=&limit=`
  - `DELETE /api/v1/tasks/{id}`
- Добавлен `ExternalTasksClient` на `RestClient`
- Настроены `baseUrl`, `User-Agent`, `Accept`, `Content-Type`, connect/read timeout
- Обработаны `201 Location`, `204 No Content`, `404 ProblemDetail`, `5xx` и неожиданный `Content-Type`

### Эмулятор внешнего API
- Добавлен `/external/v1/**` с CRUD задач
- Реализованы ответы `201 + Location`, `204`, `404 ProblemDetail`
- Добавлен `/external/v1/unstable?mode=timeout|500|429|html`

### Resilience4j
- Добавлены `@RateLimiter(name = "externalApi")` и `@CircuitBreaker(name = "externalApi")`
- Добавлены fallback-методы для graceful degradation
- Rate limiter при превышении лимита возвращает `429` 
- Circuit breaker и rate limiter настроены в `application.yaml`

### Наблюдаемость
- Добавлен `TraceIdFilter`: `X-Trace-Id`, MDC, response header
- Добавлен access log: method, path, status, timeMs, traceId
- JWT в логах маскируется, целиком не выводится
